### PR TITLE
Added support for dynamic theme switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,29 @@ import { Utterances } from '@codewithshin/svelte-utterances'
 />
 ```
 
+### Dynamic theme switching
+
+This is an example of how to reactively change the theme.
+
+```js
+<script>
+import { Utterances } from '@codewithshin/svelte-utterances'
+
+let theme = 'github-light';
+
+const switchTheme = () => {
+  theme = theme === 'github-light' ? 'github-dark' : 'github-light';
+}
+</script>
+
+<button on:click={switchTheme}>
+
+<Utterances 
+  theme={theme}
+  reponame="yourname/repo-name"
+/>
+```
+
 Check more details [Utterances](https://utteranc.es/)
 
 ## Credits

--- a/src/lib/Utterances.svelte
+++ b/src/lib/Utterances.svelte
@@ -1,20 +1,36 @@
 <script>
-  import { onMount } from "svelte";
-  export let reponame;
-  export let issueTerm = "pathname";
-  export let label = "comments";
-  export let theme = "github-light";
-  onMount(() => {
-    const s = document.createElement("script");
-    const tag = document.getElementById("utterances");
-    s.setAttribute("repo", reponame);
-    s.setAttribute("issue-term", issueTerm);
-    s.setAttribute("label", label);
-    s.setAttribute("theme", theme);
-    s.setAttribute("crossorigin", "anonymous");
-    s.src = "https://utteranc.es/client.js";
-    tag.parentNode.insertBefore(s, tag);
-  });
+	import { onMount } from 'svelte';
+  import { browser } from '$app/env';
+
+	export let reponame;
+	export let issueTerm = 'pathname';
+	export let label = 'comments';
+	export let theme = 'github-light';
+
+	let scriptElm;
+
+	if (browser) {
+		scriptElm = document.createElement('script');
+		scriptElm.setAttribute('repo', reponame);
+		scriptElm.setAttribute('issue-term', issueTerm);
+		scriptElm.setAttribute('label', label);
+		scriptElm.setAttribute('crossorigin', 'anonymous');
+		scriptElm.src = 'https://utteranc.es/client.js';
+	}
+	$: {
+		if (browser) {
+			try {
+				const iFrame = document.getElementsByTagName('iframe')[0];
+				iFrame.contentWindow.postMessage({ type: 'set-theme', theme }, 'https://utteranc.es');
+			} catch (err) {
+				// The iFrame has not been loaded yet.
+			}
+		}
+	}
+	onMount(() => {
+		const tag = document.getElementById('utterances');
+		tag.parentNode.insertBefore(scriptElm, tag);
+	});
 </script>
 
 <div id="utterances" />


### PR DESCRIPTION
# Reactive theme support

This merge request adds the ability to set the utterances theme in a reactive way, via posting a message to utterances iFrame.

**The API didn't change**, the `theme` prop can now be set to a reactive variable instead of a constant string.

These modifications were inspired by [this comment](https://github.com/utterance/utterances/issues/549#issuecomment-913070158).

I also updated `README.md` and added an example showing how to use this feature.