### PR TITLE
Fix for #3

### DIFF
--- a/src/lib/Utterances.svelte
+++ b/src/lib/Utterances.svelte
@@ -1,35 +1,38 @@
 <script>
-	import { onMount } from 'svelte';
-  import { browser } from '$app/env';
+	import { onMount } from "svelte";
 
 	export let reponame;
-	export let issueTerm = 'pathname';
-	export let label = 'comments';
-	export let theme = 'github-light';
+	export let issueTerm = "pathname";
+	export let label = "comments";
+	export let theme = "github-light";
 
 	let scriptElm;
 
-	if (browser) {
-		scriptElm = document.createElement('script');
-		scriptElm.setAttribute('repo', reponame);
-		scriptElm.setAttribute('issue-term', issueTerm);
-		scriptElm.setAttribute('label', label);
-		scriptElm.setAttribute('crossorigin', 'anonymous');
-		scriptElm.src = 'https://utteranc.es/client.js';
-	}
+	let browser = false;
+
 	$: {
 		if (browser) {
 			try {
-				const iFrame = document.getElementsByTagName('iframe')[0];
-				iFrame.contentWindow.postMessage({ type: 'set-theme', theme }, 'https://utteranc.es');
+				const iFrame = document.getElementsByClassName('utterances-frame')[0];
+				iFrame.contentWindow.postMessage(
+					{ type: "set-theme", theme },
+					"https://utteranc.es"
+				);
 			} catch (err) {
 				// The iFrame has not been loaded yet.
 			}
 		}
 	}
 	onMount(() => {
-		const tag = document.getElementById('utterances');
+		scriptElm = document.createElement("script");
+		scriptElm.setAttribute("repo", reponame);
+		scriptElm.setAttribute("issue-term", issueTerm);
+		scriptElm.setAttribute("label", label);
+		scriptElm.setAttribute("crossorigin", "anonymous");
+		scriptElm.src = "https://utteranc.es/client.js";
+		const tag = document.getElementById("utterances");
 		tag.parentNode.insertBefore(scriptElm, tag);
+		browser = true;
 	});
 </script>
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,2 +1,61 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
+<script>
+  import Utterances from "$lib/Utterances.svelte";
+  let theme = "github-light";
+
+  const switchTheme = () => {
+    theme = theme === "github-light" ? "github-dark" : "github-light";
+  };
+</script>
+
+<header>
+  <h1>Svelte Utterances component</h1>
+
+  <button on:click={switchTheme}>Toggle theme</button>
+</header>
+
+<Utterances reponame="shinokada/svelte-utterances" {theme} />
+
+<footer>
+  <a href="https://www.npmjs.com/package/@codewithshin/svelte-utterances">NPM</a
+  >
+  <a href="https://github.com/shinokada/svelte-utterances">Github</a>
+</footer>
+
+<style>
+  h1 {
+    text-align: center;
+    font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande",
+      "Lucida Sans", Arial, sans-serif;
+  }
+  button {
+    display: block;
+    margin: auto;
+    padding: 1.5em 1em;
+    cursor: pointer;
+    background-color: #8585f9;
+    color: white;
+    border: none;
+    border-radius: 7px;
+    font-family: sans-serif;
+    line-height: 0em;
+    transition: all 100ms ease-in-out;
+  }
+  button:hover {
+    box-shadow: 1px 3px 8px rgb(179, 179, 212);
+  }
+
+  footer {
+    margin: 2em 0;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    gap: 2ch;
+    text-align: center;
+    background-color: bisque;
+    font-family: "Courier New", Courier, monospace;
+  }
+  footer a {
+    line-height: 0;
+  }
+</style>


### PR DESCRIPTION
In #3 , There were 3 points made to make this package better.

> 1. Usage of $app/env - The $app alias is SvelteKit-specific and thus means that this component will not work properly on non-SvelteKit projects. This can be fixed by manually implementing your own browser check by reassigning a local browser variable in an onMount to be true.

This is now fixed by using a local variable `browser` that is `false` by default and gets switched to `true` after the component is mounted.

This should work with projects that are not built on top of sveltekit.

> 3. getElementsByTagName usage - In the theme switcher code, the call to document.getElementsByTagName('iframe')[0] will retrieve the first <iframe /> element throughout the entire page, meaning that the iFrame.contentWindow.postMessage call will fail if the website has any iframe elements placed before the component in the document.

This is now fixed by using `getElementsByClassName` so the page can have multiple `iframe` with no problem switching the `utterances` theme.

Point number 2 in that issue may gets addressed in a future update.

### index.svelte

I made a basic page showing a live demo of this package, and added links to this repo and to npm