### PR TITLE
Fix: Add theme property to script element

### DIFF
--- a/src/lib/Utterances.svelte
+++ b/src/lib/Utterances.svelte
@@ -44,6 +44,7 @@
     scriptElm.setAttribute("repo", reponame);
     scriptElm.setAttribute("issue-term", issueTerm);
     scriptElm.setAttribute("label", label);
+    scriptElm.setAttribute("theme", theme);
     scriptElm.setAttribute("crossorigin", "anonymous");
     scriptElm.src = "https://utteranc.es/client.js";
 


### PR DESCRIPTION

## This is a fix for
<!-- If this pull request closes an issue, please mention the issue number below -->
 - [#4](https://github.com/shinokada/svelte-utterances/issues/4) <!-- Issue # here -->
 - [#10](https://github.com/shinokada/svelte-utterances/pull/10)

## 📑 Description

Hello, My blog is using localstorage to save theme variables too.  

I also encountered this problem today, so I did some test, This can resolves the theme not being set correctly on page reload.

Because it didn’t pass theme property to script element 

## ℹ Additional Information

The actual effect can refer to [My blog page](https://saweicore.com/posts/2022/08/aiogram-sanic-project)
